### PR TITLE
feat: improve reset

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -116,6 +116,8 @@ def index():
 	ensure_keys()
 
 	if request.method == "GET":
+		session["skrutable_action"] = "..."
+		session.modified = True
 		return render_template(
 			'main.html',
 			text_input="",

--- a/flask_app.py
+++ b/flask_app.py
@@ -71,7 +71,6 @@ def process_form(form):
 			session[var_name] = 0
 
 	session.modified = True
-	return text_input
 
 # for meter-id resplit option, which has two parts
 def parse_complex_resplit_option(complex_resplit_option):

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -11,11 +11,17 @@
 
                             <div class="col-md-4 col-xs-4">
                                 <div class="navbar-header">
-                                    <a class="navbar-brand" style="background-color: #000;" href="./reset">skrutable</a>
+                                    <a class="navbar-brand" style="background-color: #000;" href="./">skrutable</a>
                                 </div>
                             </div>
 
-                            <div class="col-md-8 col-xs-8">
+                            <div class="col-md-2 col-xs-2">
+                                <div class="navbar-header">
+                                    <a class="navbar-brand" style="background-color: #000;" href="./reset">↻</a>
+                                </div>
+                            </div>
+
+                            <div class="col-md-6 col-xs-6">
                                 <div class="navbar-header" id="hiddenActionTitle" style="visibility: hidden">
                                     <a class="navbar-brand">: {{ skrutable_action }}</a>
                                 </div>


### PR DESCRIPTION
The former behavior was for the upper-left "skrutable" button to serve as both how to get back to home page AND a reset of all session variables. With the coming "options" page, it needs to be clearer how to get back to the home page without resetting options (e.g. those just set on the options page).

(Using the back button doesn't work well because of forms. A different option would be to add a separate "back" button to every page or to the nav bar, but then it becomes clear how weird it is that the "skrutable" button does a full reset.)

So, just add a second little button to the nav bar that does the reset. It's a little awkward, being between "skrutable" and the mode/action status label, but it's practical.

