### PR TITLE
chore: update updates page for v1.11.0

### DIFF
--- a/templates/updates.html
+++ b/templates/updates.html
@@ -7,6 +7,17 @@
 
 		<h1>significant past updates</h1>
 
+		<p>(Apr '26)</p>
+		<ul>
+			<li><a href="https://github.com/tylergneill/skrutable/pull/59" target="_blank">[lib v2.1.1]{{ ext_link_icon() }}</a> / <a href="https://pypi.org/project/skrutable/2.1.1/" target="_blank">[PyPI]{{ ext_link_icon() }}</a> / <a href="https://github.com/tylergneill/skrutable_front_end/pull/45" target="_blank">[app v1.11.0]{{ ext_link_icon() }}</a>
+				<ul>
+					<li>added anun&#257;sika / candrabindu (&#2305;) support in transliteration, with optional normalization to anusvāra</li>
+					<li>added "preserve anun&#257;sika" setting (off by default) on settings page</li>
+					<li>improved textarea font stack for better Unicode combining-diacritic rendering</li>
+				</ul>
+			</li>
+		</ul>
+
 		<p>(Feb–Mar '26)</p>
 		<ul>
 			<li><a href="https://github.com/tylergneill/skrutable/pull/56" target="_blank">[lib v2.1.0]{{ ext_link_icon() }}</a> / <a href="https://pypi.org/project/skrutable/2.1.0/" target="_blank">[PyPI]{{ ext_link_icon() }}</a> / <a href="https://github.com/tylergneill/skrutable_front_end/pull/43" target="_blank">[app v1.10.0]{{ ext_link_icon() }}</a>


### PR DESCRIPTION
## Summary

- Adds Apr '26 entry for lib v2.1.1 / app v1.11.0: anunāsika/candrabindu transliteration support, preserve-anunāsika setting, and improved textarea font stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)