### PR TITLE
chore: update updates page for v1.11.1 / lib v2.1.2 and v2.1.3

### DIFF
--- a/templates/updates.html
+++ b/templates/updates.html
@@ -9,6 +9,16 @@
 
 		<p>(Apr '26)</p>
 		<ul>
+			<li><a href="https://github.com/tylergneill/skrutable/pull/64" target="_blank">[lib v2.1.3]{{ ext_link_icon() }}</a> / <a href="https://pypi.org/project/skrutable/2.1.3/" target="_blank">[PyPI]{{ ext_link_icon() }}</a> / <a href="https://github.com/tylergneill/skrutable_front_end/pull/48" target="_blank">[app v1.11.1]{{ ext_link_icon() }}</a>
+				<ul>
+					<li>fixed VH (Velthuis) transliteration mappings for aspirate consonants and liquid vowels</li>
+				</ul>
+			</li>
+			<li><a href="https://github.com/tylergneill/skrutable/pull/60" target="_blank">[lib v2.1.2]{{ ext_link_icon() }}</a> / <a href="https://pypi.org/project/skrutable/2.1.2/" target="_blank">[PyPI]{{ ext_link_icon() }}</a>
+				<ul>
+					<li>fixed splitter server URL</li>
+				</ul>
+			</li>
 			<li><a href="https://github.com/tylergneill/skrutable/pull/59" target="_blank">[lib v2.1.1]{{ ext_link_icon() }}</a> / <a href="https://pypi.org/project/skrutable/2.1.1/" target="_blank">[PyPI]{{ ext_link_icon() }}</a> / <a href="https://github.com/tylergneill/skrutable_front_end/pull/45" target="_blank">[app v1.11.0]{{ ext_link_icon() }}</a>
 				<ul>
 					<li>added anun&#257;sika / candrabindu (&#2305;) support in transliteration, with optional normalization to anusvāra</li>


### PR DESCRIPTION
(forgot)

## Summary
- Adds entries for lib v2.1.2 (fixed splitter server URL) and lib v2.1.3 / app v1.11.1 (fixed VH transliteration mappings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)